### PR TITLE
fix: Update UI based on your feedback

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,7 +30,7 @@ body {
 
 .column h2 {
     text-align: center;
-    color: #A076F0; /* Accent color for headings */
+    color: #E0E0E0; /* Accent color for headings */
     margin-top: 0;
     font-size: 1.4em;
     font-weight: 600;
@@ -66,7 +66,7 @@ body {
 }
 
 .new-task-input {
-    width: calc(100% - 22px); /* Full width minus padding */
+    width: 100%; /* Full width minus padding */
     padding: 12px;
     margin-bottom: 10px;
     border: 1px solid #333; /* Dark border */
@@ -78,8 +78,8 @@ body {
 }
 
 .new-task-input:focus {
-    border-color: #A076F0;
-    box-shadow: 0 0 0 2px rgba(160, 118, 240, 0.3);
+    border-color: #E0E0E0;
+    box-shadow: 0 0 0 2px rgba(224, 224, 224, 0.2);
 }
 
 .new-task-input::placeholder {
@@ -87,9 +87,9 @@ body {
 }
 
 .add-task-btn {
-    background-color: #A076F0; /* Accent color for button */
-    color: #FFFFFF; /* Dark text on button for contrast */
-    border: none;
+    background-color: #2D2D2D; /* Accent color for button */
+    color: #F0F0F0; /* Dark text on button for contrast */
+    border: 1px solid #4D4D4D;
     padding: 12px 18px;
     border-radius: 4px;
     cursor: pointer;
@@ -99,23 +99,23 @@ body {
 }
 
 .add-task-btn:hover {
-    background-color: #8056D0; /* Slightly darker on hover */
+    background-color: #3D3D3D; /* Slightly darker on hover */
 }
 
 .add-task-btn:active {
     transform: translateY(1px);
-    background-color: #7046C0;
+    background-color: #1E1E1E;
 }
 
 .add-task-btn:focus {
     outline: none;
-    box-shadow: 0 0 0 3px rgba(160, 118, 240, 0.4);
+    box-shadow: 0 0 0 3px rgba(224, 224, 224, 0.3);
 }
 
 /* Class to visually indicate a column is a valid drop target */
 .drag-over {
     background-color: #222222; /* Slightly different background when dragging over */
-    border: 2px dashed #A076F0;
+    border: 2px dashed #E0E0E0;
 }
 
 /* Styling for the dragged item */


### PR DESCRIPTION
This commit addresses your feedback on the recent Vercel-inspired UI makeover:

1.  **Accent Color Changed to Monochromatic:**
    - Replaced the previous purple accent color (`#A076F0`) with a neutral monochromatic scheme.
    - Headings now use `#E0E0E0`.
    - Buttons have a new style: background `#2D2D2D`, text `#F0F0F0`, border `#4D4D4D`, with hover/active/focus states adjusted accordingly.
    - Focus rings and drag-over borders also use `#E0E0E0`.
    - This change addresses feedback that the purple color was not preferred and aims for a sleeker, more minimalist aesthetic.

2.  **Task Input Box Horizontal Alignment Fixed:**
    - Modified the `.new-task-input` CSS to ensure correct horizontal alignment within columns.
    - Changed `width` from `calc(100% - 22px)` to `100%` and confirmed `box-sizing: border-box;` is active. This allows the input field to properly span the column width while respecting its padding.

These changes refine the UI according to your preferences and fix a layout issue.