### PR TITLE
fix: Ensure page title is correctly centered

### DIFF
--- a/style.css
+++ b/style.css
@@ -147,4 +147,6 @@ h1 {
     text-align: center;
     margin-bottom: 30px;
     font-weight: bold;
+    display: block; /* Explicitly set display type */
+    width: 100%;   /* Ensure it spans full width */
 }


### PR DESCRIPTION
Updated the CSS for the H1 page title ("Jules Kanban") to include `display: block;` and `width: 100%;`.
This ensures the text within the H1 element is properly centered across the full width of the page, correcting a previous alignment issue where it might have appeared off-center depending on other body styles.