### PR TITLE
fix: Correct page title and board centering

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,9 +3,10 @@ body {
     background-color: #0A0A0A; /* Dark background */
     color: #F0F0F0; /* Light text */
     margin: 0;
-    padding: 40px;
+    padding: 40px; /* This padding will apply to all sides */
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
 }
 
 .kanban-board {


### PR DESCRIPTION
Modified the body's CSS flex properties to `flex-direction: column` and `align-items: center`. This ensures that the H1 page title and the main kanban board content are stacked vertically and correctly centered horizontally on the page.

The H1 title itself retains `width: 100%` and `text-align: center` to ensure its text is centered within its full-width block.

This resolves an issue where the title was appearing on the left side of the page instead of being centered at the top.