### PR TITLE
Fix: Center page title above Kanban board

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,9 +4,6 @@ body {
     color: #F0F0F0; /* Light text */
     margin: 0;
     padding: 40px; /* This padding will apply to all sides */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
 }
 
 .kanban-board {


### PR DESCRIPTION
The main page title "Jules Kanban" was reportedly displaying incorrectly on the top-left with the Kanban columns to its right.

This commit modifies the `body` CSS to use standard block layout instead of flexbox for its main children (the `h1` title and the `.kanban-board`).

- Removed `display: flex`, `flex-direction: column`, and
  `align-items: center` from the `body` style.

The `h1` element already had `width: 100%` and `text-align: center`, which will center its text correctly in a block layout. The `.kanban-board` element already had `margin: 0 auto` and appropriate width/max-width settings to center itself as a block.

This change ensures the title is displayed centered horizontally at the top of the page, directly above the similarly centered Kanban board.