### PR TITLE
feat: Implement task deletion functionality

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,10 +18,24 @@ document.addEventListener('DOMContentLoaded', () => {
                 const tasksInColumn = column.querySelectorAll('.tasks .task');
                 tasksByColumn[columnId] = [];
                 tasksInColumn.forEach(taskElement => {
-                    tasksByColumn[columnId].push({
-                        id: taskElement.id,
-                        text: taskElement.textContent
-                    });
+                    const textSpan = taskElement.querySelector('.task-text-content');
+                    if (textSpan) {
+                        tasksByColumn[columnId].push({
+                            id: taskElement.id,
+                            text: textSpan.textContent.trim()
+                        });
+                    } else {
+                        // Fallback or error handling if the structure is not as expected
+                        // This might happen if old tasks without the span are somehow still in localStorage
+                        // or if there's a bug in createTaskElement.
+                        // For now, we'll try to grab the whole textContent and hope for the best,
+                        // but ideally, this case should be handled more gracefully or logged.
+                        console.warn(`Task element with ID ${taskElement.id} is missing 'task-text-content' span. Attempting fallback text extraction.`);
+                        tasksByColumn[columnId].push({
+                            id: taskElement.id,
+                            text: taskElement.textContent.replace(/X$/, '').trim() // Try to remove trailing X
+                        });
+                    }
                 });
             });
             localStorage.setItem('kanbanData', JSON.stringify(tasksByColumn));
@@ -70,7 +84,22 @@ document.addEventListener('DOMContentLoaded', () => {
         task.classList.add('task');
         task.setAttribute('draggable', 'true');
         task.id = taskId || generateId();
-        task.textContent = taskText; // Text content is already sanitized by DOM manipulation
+
+        // Create a span for the task text
+        const textSpan = document.createElement('span');
+        textSpan.classList.add('task-text-content');
+        textSpan.textContent = taskText;
+        task.appendChild(textSpan);
+
+        const deleteBtn = document.createElement('span');
+        deleteBtn.classList.add('delete-task-btn');
+        deleteBtn.textContent = 'X';
+        deleteBtn.addEventListener('click', () => {
+            task.remove();
+            saveTasks();
+        });
+
+        task.appendChild(deleteBtn);
 
         task.addEventListener('dragstart', handleDragStart);
         task.addEventListener('dragend', handleDragEnd);

--- a/style.css
+++ b/style.css
@@ -56,6 +56,31 @@ body {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
     border: 1px solid #383838;
     font-size: 0.9em;
+    position: relative; /* Added for positioning delete button */
+}
+
+.delete-task-btn {
+    position: absolute;
+    top: 50%; /* Changed for vertical centering */
+    right: 5px; /* Adjusted for potentially wider padding */
+    transform: translateY(-50%); /* Added for vertical centering */
+    color: #bbb; /* Softer grey */
+    font-size: 16px;
+    font-weight: 300; /* Thinner 'X' */
+    cursor: pointer;
+    padding: 3px 6px; /* Slightly increased padding */
+    border-radius: 3px;
+    /* border: 1px solid #555; */ /* Removed border */
+    transition: background-color 0.2s ease, color 0.2s ease; /* Removed border-color from transition */
+    display: flex; /* Added for Flexbox alignment */
+    align-items: center; /* Vertically center 'X' */
+    justify-content: center; /* Horizontally center 'X' */
+}
+
+.delete-task-btn:hover {
+    background-color: #E57373; /* Soft red background */
+    color: #fff; /* White 'X' for contrast */
+    /* border-color: #D32F2F; */ /* Removed border-color from hover */
 }
 
 .task:active {


### PR DESCRIPTION
Adds a delete button (styled 'X') to each task card, allowing you to remove tasks from the Kanban board.

Key changes:
- Modified `script.js` to:
  - Dynamically create a delete button within each task element in `createTaskElement`.
  - Wrap task text in a `span.task-text-content` to reliably separate it from the delete button.
  - Add an event listener to the delete button to remove the task from the DOM.
  - Update `saveTasks` to correctly save only the task text (using `querySelector('.task-text-content')`) and persist deletions in local storage. Includes a fallback for older data.
- Modified `style.css` to:
  - Style the delete button for clear visibility, appropriate positioning (top-right, vertically centered on the task), and user-friendly hover effects.
  - Ensure the parent `.task` element has `position: relative`.
  - Use Flexbox to center the 'X' within the delete button.
  - Use `top: 50%; transform: translateY(-50%);` to center the button itself on the task.

The implementation addresses an 'X' duplication bug that occurred on page refresh and incorporates several styling refinements based on your feedback to ensure proper alignment and appearance of the delete button.