### PR TITLE
feat: Enhance Kanban board usability

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,6 +133,15 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
+    taskInputs.forEach((inputField, index) => {
+        inputField.addEventListener('keypress', (event) => {
+            if (event.key === 'Enter') {
+                event.preventDefault(); // Prevent default form submission or line break
+                addTaskButtons[index].click(); // Trigger click on corresponding add button
+            }
+        });
+    });
+
     function handleDragStart(e) {
         draggedTask = e.target;
         // Basic check: Ensure it's a task being dragged

--- a/style.css
+++ b/style.css
@@ -76,7 +76,7 @@ body {
     border-radius: 3px;
     /* border: 1px solid #555; */ /* Removed border */
     transition: background-color 0.2s ease, color 0.2s ease; /* Removed border-color from transition */
-    display: flex; /* Added for Flexbox alignment */
+    display: none; /* Changed for Flexbox alignment */
     align-items: center; /* Vertically center 'X' */
     justify-content: center; /* Horizontally center 'X' */
 }
@@ -85,6 +85,10 @@ body {
     background-color: #E57373; /* Soft red background */
     color: #fff; /* White 'X' for contrast */
     /* border-color: #D32F2F; */ /* Removed border-color from hover */
+}
+
+.task:hover .delete-task-btn {
+    display: flex;
 }
 
 .task:active {


### PR DESCRIPTION
This commit introduces two UI/UX improvements:

1. Delete buttons on tasks are now hidden by default and only appear when you hover over the respective task. This provides a cleaner interface.

2. You can now add tasks by pressing the Enter key in the new task input fields, in addition to clicking the 'Add Task' button. This streamlines the task creation process.

Both features have been tested and confirmed to be working as expected.