### PR TITLE
refactor: Further darken and violet-shift background gradient

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,9 +1,11 @@
 body {
     font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-    background-color: #0A0A0A; /* Dark background */
+    background-image: radial-gradient(ellipse at top center, #1f003f 0%, #000000 85%);
     color: #F0F0F0; /* Light text */
     margin: 0;
     padding: 40px; /* This padding will apply to all sides */
+    min-height: 100vh;
+    box-sizing: border-box;
 }
 
 .kanban-board {


### PR DESCRIPTION
This commit makes additional refinements to the background radial gradient based on your feedback, aiming for a slightly darker and more violet hue.

The `body` element in `style.css` now uses:
`background-image: radial-gradient(ellipse at top center, #1f003f 0%, #000000 85%);`

The starting color `#1f003f` is a darker and more violet shade than the previous iteration, while maintaining the subtle transition to black at 85%.