### PR TITLE
Add task editing functionality to Kanban board

### DIFF
--- a/script.js
+++ b/script.js
@@ -91,6 +91,40 @@ document.addEventListener('DOMContentLoaded', () => {
         textSpan.textContent = taskText;
         task.appendChild(textSpan);
 
+        const editBtn = document.createElement('span');
+        editBtn.classList.add('edit-task-btn');
+        editBtn.textContent = 'Edit'; // Or use an icon
+        editBtn.addEventListener('click', () => {
+            if (task.classList.contains('editing')) {
+                // Currently in edit mode, so save
+                const inputField = task.querySelector('.edit-task-input');
+                textSpan.textContent = inputField.value;
+                task.replaceChild(textSpan, inputField);
+                task.classList.remove('editing');
+                editBtn.textContent = 'Edit';
+                task.setAttribute('draggable', 'true'); // Re-enable dragging
+                saveTasks();
+            } else {
+                // Not in edit mode, so switch to edit
+                const currentText = textSpan.textContent;
+                const inputField = document.createElement('input');
+                inputField.type = 'text';
+                inputField.classList.add('edit-task-input');
+                inputField.value = currentText;
+                task.replaceChild(inputField, textSpan);
+                task.classList.add('editing');
+                editBtn.textContent = 'Save';
+                task.setAttribute('draggable', 'false'); // Disable dragging while editing
+                inputField.focus();
+                // Optional: Save on Enter key press
+                inputField.addEventListener('keypress', (e) => {
+                    if (e.key === 'Enter') {
+                        editBtn.click(); // Simulate click on save button
+                    }
+                });
+            }
+        });
+
         const deleteBtn = document.createElement('span');
         deleteBtn.classList.add('delete-task-btn');
         deleteBtn.textContent = 'X';
@@ -99,9 +133,16 @@ document.addEventListener('DOMContentLoaded', () => {
             saveTasks();
         });
 
+        task.appendChild(editBtn);
         task.appendChild(deleteBtn);
 
-        task.addEventListener('dragstart', handleDragStart);
+        task.addEventListener('dragstart', (e) => {
+            if (task.classList.contains('editing')) {
+                e.preventDefault(); // Prevent dragging if in edit mode
+                return;
+            }
+            handleDragStart(e);
+        });
         task.addEventListener('dragend', handleDragEnd);
 
         // Touch event listeners

--- a/style.css
+++ b/style.css
@@ -90,8 +90,61 @@ body {
     color: #fff; /* White 'X' for contrast */
 }
 
-.task:hover .delete-task-btn {
+.task:hover .delete-task-btn,
+.task:hover .edit-task-btn {
     display: flex;
+}
+
+.edit-task-btn {
+    position: absolute;
+    top: 50%;
+    right: 30px; /* Position next to delete button */
+    transform: translateY(-50%);
+    color: #bbb;
+    font-size: 14px; /* Slightly smaller to differentiate or match delete */
+    font-weight: 300;
+    cursor: pointer;
+    padding: 3px 6px;
+    border-radius: 3px;
+    background-color: transparent;
+    border: none;
+    transition: color 0.2s ease;
+    display: none;
+    align-items: center;
+    justify-content: center;
+}
+
+.edit-task-btn:hover {
+    background-color: transparent;
+    border: none;
+    color: #fff;
+}
+
+.edit-task-input {
+    width: calc(100% - 50px); /* Adjust width to leave space for buttons */
+    padding: 8px;
+    margin: -8px 0; /* Adjust margin to fit nicely */
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 3px;
+    background-color: rgba(31, 0, 63, 0.1); /* Similar to new-task-input */
+    color: #F0F0F0;
+    box-sizing: border-box;
+    font-family: inherit; /* Inherit font from task */
+    font-size: inherit; /* Inherit font size from task */
+}
+
+.edit-task-input:focus {
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.45);
+}
+
+/* Adjust delete button position if edit button is present */
+.task .delete-task-btn {
+    right: 5px; /* Original position */
+}
+
+.task.editing .task-text-content {
+    display: none; /* Hide original text when editing */
 }
 
 .task:active {


### PR DESCRIPTION
- Added an 'Edit' button to each task.
- Clicking 'Edit' allows in-place modification of the task text.
- 'Edit' button changes to 'Save' during editing.
- Task dragging is disabled while in edit mode.
- Changes are saved to local storage.
- Styled new elements to match the existing UI.