### PR TITLE
Fix: Refine dark mode theme switch aesthetics

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,14 @@
     <div class="theme-switch-container">
         <label class="theme-switch" for="theme-switch-checkbox">
             <input type="checkbox" id="theme-switch-checkbox" />
-            <div class="slider round"></div>
+            <div class="slider round">
+                <span class="icon sun-icon">
+                    <svg viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+                </span>
+                <span class="icon moon-icon">
+                    <svg viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+                </span>
+            </div>
         </label>
     </div>
     <h1>Jules Kanban</h1>

--- a/style.css
+++ b/style.css
@@ -431,8 +431,8 @@ h1 {
 .theme-switch {
     position: relative;
     display: inline-block;
-    width: 60px;
-    height: 34px;
+    width: 50px; /* Reduced width */
+    height: 28px; /* Reduced height */
 }
 
 .theme-switch input {
@@ -448,58 +448,159 @@ h1 {
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: #ccc;
+    background-color: rgba(204, 204, 204, 0.3); /* Light grey with alpha for glass base */
+    backdrop-filter: blur(5px);
+    border: 1px solid rgba(255, 255, 255, 0.18);
     transition: .4s;
-    border-radius: 34px;
+    border-radius: 28px; /* Adjusted border-radius */
 }
 
 .slider:before {
     position: absolute;
     content: "";
-    height: 26px;
-    width: 26px;
-    left: 4px;
-    bottom: 4px;
-    background-color: white;
+    height: 20px; /* Reduced nub height */
+    width: 20px;  /* Reduced nub width */
+    left: 3px;    /* Adjusted nub position */
+    bottom: 3px;  /* Adjusted nub position */
+    background-color: rgba(255, 255, 255, 0.8); /* Slightly transparent white */
     transition: .4s;
     border-radius: 50%;
+    box-shadow: 0 0 3px rgba(0,0,0,0.2);
+    z-index: 1; /* Ensure nub is above icons */
 }
 
-input:checked + .slider {
-    background-color: #2196F3; /* Blue when checked (light mode) */
+/* Icons inside the slider */
+.slider .icon {
+    position: absolute;
+    top: 50%; /* Default for sun */
+    transform: translateY(-50%); /* Default for sun */
+    width: 16px; /* Icon size */
+    height: 16px;
+    pointer-events: none; /* So they don't interfere with clicks */
+    transition: opacity 0.3s ease, color 0.3s ease;
+    z-index: 0; /* Below the nub */
 }
+
+.slider .sun-icon {
+    left: 5px; /* Position on the left */
+    /* Default state (switch OFF, dark mode selected): Sun is hidden, but color if it were visible */
+    color: #FFD700; /* Gold for sun */
+    opacity: 0;
+}
+
+.slider .moon-icon {
+    right: 5px; /* Position on the right */
+    /* Default state (switch OFF, dark mode selected): Moon is visible */
+    color: #b0c4de; /* LightSteelBlue for moon */
+    opacity: 1;
+    transform: translateY(-51%); /* Nudge moon icon up slightly */
+}
+
+/* Styles based on checkbox state (determines which icon is conceptually 'active') */
+/* When switch is ON (light mode selected) */
+input:checked + .slider .sun-icon {
+    opacity: 1; /* Show sun */
+}
+input:checked + .slider .moon-icon {
+    opacity: 0; /* Hide moon */
+}
+
+/* When switch is OFF (dark mode selected) - this is the default state of icons */
+input:not(:checked) + .slider .sun-icon {
+    opacity: 0; /* Hide sun */
+}
+input:not(:checked) + .slider .moon-icon {
+    opacity: 1; /* Show moon */
+}
+
+
+/* Slider background color based on checkbox state */
+input:checked + .slider { /* Light mode selected */
+    background-color: rgba(255, 235, 205, 0.5); /* SeaShell/Very Light Peach-Gold glass */
+    border-color: rgba(210, 180, 140, 0.4); /* Tan border, subtle */
+}
+
+input:not(:checked) + .slider { /* Dark mode selected - this is the default slider bg */
+    /* This will be overridden by body:not(.light-mode) .theme-switch .slider for initial dark theme load */
+    /* And by body.light-mode .theme-switch .slider if light theme is active but switch is toggled to dark */
+}
+
 
 input:focus + .slider {
-    box-shadow: 0 0 1px #2196F3;
+    box-shadow: 0 0 2px rgba(210, 180, 140, 0.7); /* Focus consistent with new 'on' color */
 }
 
 input:checked + .slider:before {
-    transform: translateX(26px);
+    transform: translateX(22px); /* Adjusted transform for new size */
 }
 
-/* Style for dark mode (default) */
-body:not(.light-mode) .slider {
-    background-color: #555; /* Darker background for the switch in dark mode */
+/* Theme-specific overrides for icon colors and slider background */
+
+/* === DARK THEME (body:not(.light-mode)) === */
+body:not(.light-mode) .theme-switch .slider { /* Default slider bg in dark mode (switch OFF) */
+    background-color: rgba(85, 85, 85, 0.4); /* Darker glass base */
+    backdrop-filter: blur(5px);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+}
+body:not(.light-mode) .theme-switch input:not(:checked) + .slider .moon-icon { /* Moon icon when dark mode is active & selected */
+    color: #b0c4de; /* LightSteelBlue */
+    opacity: 1;
+}
+body:not(.light-mode) .theme-switch input:not(:checked) + .slider .sun-icon { /* Sun icon when dark mode is active & selected (should be hidden) */
+    opacity: 0;
+}
+body:not(.light-mode) .theme-switch input:checked + .slider { /* Slider bg in dark mode when switch is ON (light mode selected) */
+    background-color: rgba(255, 235, 205, 0.5); /* SeaShell/Very Light Peach-Gold glass */
+    border-color: rgba(210, 180, 140, 0.4);
+}
+body:not(.light-mode) .theme-switch input:checked + .slider .sun-icon { /* Sun icon when dark mode is active BUT light mode selected */
+    color: #FFD700; /* Gold */
+    opacity: 1;
+}
+body:not(.light-mode) .theme-switch input:checked + .slider .moon-icon { /* Moon icon when dark mode is active BUT light mode selected (should be hidden) */
+    opacity: 0;
+}
+body:not(.light-mode) .theme-switch .slider:before { /* Nub color in dark mode (when dark theme is selected) */
+    background-color: rgba(180, 180, 180, 0.75); /* Darker, more transparent grey */
+    box-shadow: 0 0 2px rgba(0,0,0,0.3); /* Slightly adjusted shadow for new nub color */
+}
+body:not(.light-mode) .theme-switch input:checked + .slider:before { /* Nub when light is selected, still in dark body theme context */
+    background-color: rgba(235, 235, 235, 0.85); /* Slightly less stark white for this transitional state */
 }
 
-body:not(.light-mode) input:checked + .slider {
-    background-color: #777; /* Slightly lighter dark background when "on" but still dark overall */
+
+/* === LIGHT THEME (body.light-mode) === */
+body.light-mode .theme-switch .slider { /* Default slider bg in light mode (switch ON for light) */
+    /* This is when light mode is selected (checkbox is checked) */
+    background-color: rgba(255, 235, 205, 0.6); /* SeaShell/Very Light Peach-Gold glass - slightly more opaque */
+    backdrop-filter: blur(5px);
+    border: 1px solid rgba(210, 180, 140, 0.4); /* Tan border */
+}
+body.light-mode .theme-switch input:checked + .slider .sun-icon { /* Sun icon when light mode is active & selected */
+    color: #e68a00; /* Darker Gold / Orange for better contrast on light bg */
+    opacity: 1;
+}
+body.light-mode .theme-switch input:checked + .slider .moon-icon { /* Moon icon when light mode is active & selected (should be hidden) */
+    opacity: 0;
 }
 
-body:not(.light-mode) .slider:before {
-    background-color: #ddd; /* Lighter nub for dark mode */
+body.light-mode .theme-switch input:not(:checked) + .slider { /* Slider bg in light mode when switch is OFF (dark mode selected) */
+    background-color: rgba(130, 130, 130, 0.4); /* Mid-tone grey glass for 'off' state in light mode */
+    border: 1px solid rgba(0, 0, 0, 0.15);
+}
+body.light-mode .theme-switch input:not(:checked) + .slider .moon-icon { /* Moon icon when light mode is active BUT dark mode selected */
+    color: #333a45; /* Darker slate gray for moon on light bg */
+    opacity: 1;
+}
+body.light-mode .theme-switch input:not(:checked) + .slider .sun-icon { /* Sun icon when light mode is active BUT dark mode selected (should be hidden) */
+    opacity: 0;
 }
 
-/* Specific style for the sun/moon icons if we add them later, or for the nub color in light/dark */
-/* For now, we'll adjust the nub for light mode when .light-mode is active on body */
-body.light-mode .slider {
-    background-color: #ccc; /* Standard light mode off */
+body.light-mode .theme-switch .slider:before { /* Nub color in light mode (when light is selected by default with this body class) */
+    background-color: rgba(255, 255, 255, 0.95);
 }
-body.light-mode input:checked + .slider {
-    background-color: #2196F3; /* Standard light mode on */
-}
-body.light-mode .slider:before {
-    background-color: white; /* Standard light mode nub */
+body.light-mode .theme-switch input:not(:checked) + .slider:before { /* Nub when dark is selected, still in light body theme context */
+    background-color: rgba(240, 240, 240, 0.9);
 }
 
 /* Light Theme Styles */


### PR DESCRIPTION
- Adjusted the slider nub color in dark mode to a softer, semi-transparent grey (`rgba(180, 180, 180, 0.75)`) for better visual integration with the dark glass theme.
- Fine-tuned the vertical alignment of the moon icon using `transform: translateY(-51%)` to ensure it is perfectly centered.