### PR TITLE
fix: Correct board title hover shift and edit icon alignment

### DIFF
--- a/assets/css/board.css
+++ b/assets/css/board.css
@@ -93,6 +93,7 @@ body.light-mode .home-button:hover svg { fill: var(--light-text); }
     transition: background-color var(--transition-fast), color var(--transition-fast);
     cursor: pointer;
     color: var(--dark-text);
+    box-sizing: border-box; /* Add for layout stability */
 }
 body.light-mode #board-name-display { color: var(--light-text); }
 
@@ -107,8 +108,11 @@ body.light-mode #board-name-display:hover {
     /* display: none; Initially hidden by JS */
     margin-left: 12px;
     cursor: pointer;
-    transition: color var(--transition-fast);
+    transition: color var(--transition-fast), opacity var(--transition-fast); /* Added opacity to transition */
     opacity: 0.6; /* Make it less prominent initially */
+    display: inline-flex; /* For better alignment of SVG inside */
+    align-items: center;   /* Vertically center SVG inside the span */
+    justify-content: center; /* Horizontally center SVG (though less critical for single SVG) */
 }
 .edit-board-icon:hover { opacity: 1; }
 


### PR DESCRIPTION
- Resolved issue where hovering board title caused a layout shift by adding `box-sizing: border-box;` to `#board-name-display` in `board.css`.
- Fixed vertical misalignment of the edit icon (`#edit-board-name-icon`):
    - Applied `display: inline-flex; align-items: center; justify-content: center;` to the icon's span container to ensure the SVG is centered within it and the span aligns correctly as a flex item in `.board-header`.
- Improved overall aesthetics of the board title area:
    - Added `opacity` to the `transition` property of `#edit-board-name-icon` for smoother appearance/disappearance on hover.